### PR TITLE
fix init and accelGyro example

### DIFF
--- a/DFRobot_BMI160.cpp
+++ b/DFRobot_BMI160.cpp
@@ -29,7 +29,6 @@ const uint8_t int_mask_lookup_table[13] = {
 
 DFRobot_BMI160::DFRobot_BMI160()
 {
-  Wire.begin();
   Obmi160=(struct bmi160Dev *)malloc(sizeof(struct bmi160Dev));
   //Obmi160->id = BMI160_I2C_ADDR;
   //Obmi160->interface = BMI160_I2C_INTF; 
@@ -39,6 +38,7 @@ DFRobot_BMI160::DFRobot_BMI160()
   
 int8_t DFRobot_BMI160::I2cInit(int8_t i2c_addr)
 {
+  Wire.begin();
   Obmi160->id = i2c_addr;
   Obmi160->interface = BMI160_I2C_INTF;
   return DFRobot_BMI160::I2cInit(Obmi160);

--- a/examples/accelGyro/accelGyro.ino
+++ b/examples/accelGyro/accelGyro.ino
@@ -24,12 +24,6 @@ void setup(){
   Serial.begin(115200);
   delay(100);
   
-  //init the hardware bmin160  
-  if (bmi160.softReset() != BMI160_OK){
-    Serial.println("reset false");
-    while(1);
-  }
-  
   //set and init the bmi160 i2c address
   if (bmi160.I2cInit(i2c_addr) != BMI160_OK){
     Serial.println("init false");


### PR DESCRIPTION
`The init of the i2c device was somehow broken, now it should work with also bluepill boards and adafruit feather m0 logger. Also the accelGyro example is using softreset method which I don't see how that even is working. I think that shouldn't be in the example`
closes: #7 
closes: #8 